### PR TITLE
Add "root" parameter to getPath function.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,21 +2,22 @@ var stack = require('callsite'),
     path = require('path'),
     fs = require('fs');
 
-function getPath(nmPath, workingDir) {
+function getPath(nmPath, workingDir, root) {
     var pathToCheck = path.resolve(workingDir, 'node_modules', nmPath);
 
     if (fs.existsSync(pathToCheck)) {
         return pathToCheck;
     }
 
-    if (workingDir ==='/') {
-        throw new Error('Unable to resolve "' + nmPath +'"');
+    if (workingDir === root) {
+        throw new Error('Unable to resolve "' + nmPath + '"');
     }
 
-    return getPath(nmPath, path.dirname(workingDir));
+    return getPath(nmPath, path.dirname(workingDir), root);
 }
 
 module.exports = function(nmPath) {
     var initialPath = path.dirname(stack()[1].getFileName());
-    return getPath(nmPath, initialPath);
+    var root = path.parse(initialPath).root;
+    return getPath(nmPath, initialPath, root);
 };


### PR DESCRIPTION
Add "root" parameter in order to fix never-ending recursion on Windows.