### PR TITLE
fix: Add "root" parameter to "getPath" function.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,21 +2,22 @@ var stack = require('callsite'),
     path = require('path'),
     fs = require('fs');
 
-function getPath(nmPath, workingDir) {
+function getPath(nmPath, workingDir, root) {
     var pathToCheck = path.resolve(workingDir, 'node_modules', nmPath);
 
     if (fs.existsSync(pathToCheck)) {
         return pathToCheck;
     }
 
-    if (workingDir ==='/') {
+    if (workingDir === root) {
         throw new Error('Unable to resolve "' + nmPath +'"');
     }
 
-    return getPath(nmPath, path.dirname(workingDir));
+    return getPath(nmPath, path.dirname(workingDir), root);
 }
 
 module.exports = function(nmPath) {
-    var initialPath = path.dirname(stack()[1].getFileName());
-    return getPath(nmPath, initialPath);
+    var initialPath = path.dirname(stack()[1].getFileName()),
+        root = path.parse(initialPath).root;
+    return getPath(nmPath, initialPath, root);
 };


### PR DESCRIPTION
Add "root" parameter to "getPath" function in order to avoid stack overflow on Windows due to infinite recursion.